### PR TITLE
Added changes to allow project to run on mac.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+
+venv/
+
+microbit/db.sqlite3
+
+microbit/microbit/__pycache__/
+
+microbit/microbit_lightsensor/__pycache__/
+
+microbit/microbit_lightsensor/migrations/__pycache__/
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ NOTES :
 - sudo usermod -aG dialout <username> , then restart your machine. in terminal type groups and you should see 'dialout' on the list 
 
 - Once all this goes well you should be able to run it and get the output from your microbit 
+
+Notes for setup on Mac
+
+- to make sure the connected microbit is receiving data through the serial port, we first need to determine with port it is on.
+This port will be of the form cu.

--- a/microbit/microbit/urls.py
+++ b/microbit/microbit/urls.py
@@ -22,4 +22,5 @@ from . import settings
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('home/', views.home, name='home'),
+    path('', views.home ),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/microbit/microbit_lightsensor/readserial.py
+++ b/microbit/microbit_lightsensor/readserial.py
@@ -1,8 +1,16 @@
 import os
 import serial
+import platform
 
-ser = serial.Serial('/dev/ttyACM0', 115200)
-ser.flushInput() 
+
+type#For Linux
+if platform.system() == "Linux":
+    ser = serial.Serial('/dev/ttyACM0', 115200)
+else:
+#For Mac
+    ser = serial.Serial('/dev/cu.usbmodem144302', 115200)
+
+ser.flushInput()
 
 
 def updateContext ():


### PR DESCRIPTION
I would like to request a pull for the changes made to run the project on a mac. The only caveat is that the port name will need to be manually changed on a mac by looking at /dev/ ls -l cu.* to find the name of the port. This name should then be included in the readserial.py file.